### PR TITLE
org-gcal-post-at-point with preserved TODO keyword and tags

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -318,7 +318,7 @@ current calendar."
                                            (save-excursion (outline-next-heading) (point)))
                         (goto-char (match-beginning 0))
                         (org-element-timestamp-parser)))
-           (smry (org-element-property :title elem))
+           (smry (concat (nth 2 (org-heading-components)) " " (nth 4 (org-heading-components)) " " (nth 5 (org-heading-components))))
            (loc (org-element-property :LOCATION elem))
            (id (org-element-property :ID elem))
            (start (org-gcal--format-org2iso


### PR DESCRIPTION
Each time the user posts a new item to Google item, the TODO keyword and tags will be preserved. 

Solves issue #29